### PR TITLE
Buffer input from zone1 before sending

### DIFF
--- a/zone1/cli.c
+++ b/zone1/cli.c
@@ -397,9 +397,8 @@ void cliTask( void *pvParameters){
     char c = 0;
 	mzmsg_init(&zone2, 2);
 
-    // TODO: Uncomment after we devise a faster mzmsg protocol
-    // mzmsg_write(&zone2, welcome_msg, sizeof(welcome_msg));
-    // print_cpu_info();
+    mzmsg_write(&zone2, welcome_msg, sizeof(welcome_msg));
+    print_cpu_info();
 	mzmsg_write(&zone2, "\nFreeRTOS CLI\n",16);
 
     char cmd_line[CMD_LINE_SIZE+1]="";

--- a/zone1/mzmsg.c
+++ b/zone1/mzmsg.c
@@ -11,6 +11,7 @@
 #define CTL_ACK    (1 << 0)
 #define CTL_DAT    (1 << 1)
 #define CTL_RST    (1 << 2)
+#define CTL_PSH    (1 << 3)
 
 void mzmsg_reset(mzmsg_t *mzmsg){
 
@@ -123,10 +124,14 @@ int mzmsg_write(mzmsg_t *mzmsg, char *buf, size_t len){
             mzmsg->out[DAT] = *buf++;
             mzmsg->out[IND] = ack_index;
             count++;
+            if (count == len)
+                mzmsg->out[CTL] |= CTL_PSH;
 
             ack_pending = 1;
             
             mzmsg_flush(mzmsg);
+
+            mzmsg->out[CTL] &= ~CTL_PSH;
         } 
         
     }


### PR DESCRIPTION
picoTCP is inefficient when transmitting 1 character at a time so buffer
the input in a ring buffer and flush it. This meant adding another CTL
keyword, CTL_PSH, which signals the push.