### PR TITLE
Support latest GDB and bitstreams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,16 @@ export AR      := $(CROSS_COMPILE)ar
 
 BOARD ?= E31
 ifeq ($(BOARD),E31)
-	RISCV_ARCH := rv32imac
+	ARCH := rv32
+	RISCV_ARCH := $(ARCH)imac
 	RISCV_ABI := ilp32
 else ifeq ($(BOARD),E51)
-	RISCV_ARCH := rv64imac
+	ARCH := rv64
+	RISCV_ARCH := $(ARCH)imac
 	RISCV_ABI := lp64
 else ifeq ($(BOARD),S51)
-	RISCV_ARCH := rv64imac
+	ARCH := rv64
+	RISCV_ARCH := $(ARCH)imac
 	RISCV_ABI := lp64
 else
 	$(error Unsupported board $(BOARD))
@@ -81,6 +84,7 @@ GDB_PORT ?= 3333
 GDB_LOAD_ARGS ?= --batch
 GDB_LOAD_CMDS += -ex "set mem inaccessible-by-default off"
 GDB_LOAD_CMDS += -ex "set remotetimeout 240"
+GDB_LOAD_CMDS += -ex "set arch riscv:$(ARCH)"
 GDB_LOAD_CMDS += -ex "target extended-remote localhost:$(GDB_PORT)"
 GDB_LOAD_CMDS += -ex "monitor reset halt"
 GDB_LOAD_CMDS += -ex "monitor flash protect 0 64 last off"


### PR DESCRIPTION
- Fix for latest GDB - set the architecture to GDB
- Support latest bitstreams - dynamically add offset depending on bitstream/core version

Recommend rebasing this work atop instead of merging. I've tested the PLIC on E31 v3p0, E31 v19.02 and S51 v19.02. I did not have access to E51 v3p0, please retest on this one just to be sure.

This fixes https://github.com/hex-five/multizone-sdk/issues/37.