### PR TITLE
Replace `echo` with `printf` since `echo` is not portable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ GDB_LOAD_CMDS += -ex "quit"
 ifeq ($(BOARD),FE310)
 
 load:
-	echo "loadfile multizone.hex\nrnh\nexit\n" | JLinkExe -device FE310 -if JTAG -speed 4000 -jtagconf -1,-1 -autoconnect 1
+	printf "loadfile multizone.hex\nrnh\nexit\n" | JLinkExe -device FE310 -if JTAG -speed 4000 -jtagconf -1,-1 -autoconnect 1
 
 else
 


### PR DESCRIPTION
# `echo` is not portable

On some systems (e.g. mine) the `\n` escape sequences aren't interpreted as such.

`printf` should always be prefered, as it is portable. See [this stackexchange answer](https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo) or [this commit in git/git](https://github.com/git/git/commit/1a6d46895d30459efe2d258c6e0a208f00f2b043) for reference.